### PR TITLE
Segment on purchase product

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use MauticPlugin\MauticEcommerceBundle as Bundle;
+use MauticPlugin\MauticEcommerceBundle\Controller\AjaxController;
 use MauticPlugin\MauticEcommerceBundle\Email\Parser;
 use MauticPlugin\MauticEcommerceBundle\EventListener\EmailSubscriber;
+use MauticPlugin\MauticEcommerceBundle\Segment\Query\Filter\PurchaseProductFilterQueryBuilder;
 
 return [
     'name' => 'Ecommerce',
@@ -133,6 +135,9 @@ return [
             ],
         ],
         'others' => [
+            PurchaseProductFilterQueryBuilder::getServiceId() => [
+                'class' => PurchaseProductFilterQueryBuilder::class
+            ],
             'mautic_ecommerce.email.parser' => [
                 'class' => Parser::class,
                 'arguments' => [

--- a/Controller/AjaxController.php
+++ b/Controller/AjaxController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MauticPlugin\MauticEcommerceBundle\Controller;
+
+use MauticPlugin\MauticEcommerceBundle\Entity\Product;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class AjaxController extends AbstractController
+{
+    public function executeAjaxAction(string $action, Request $request, string $bundle): JsonResponse
+    {
+        $productRepository = $this->get('mautic_ecommerce.repository.product');
+        $term = $request->query->get('filter');
+
+        $products = $productRepository->search($term);
+
+        return new JsonResponse(
+            array_merge(
+                ['success' => true],
+                array_map(static function (Product $product): array {
+                    return ['value' => $product->getName(), 'id' => $product->getId()];
+                }, $products)
+            )
+        );
+    }
+}

--- a/Entity/ProductRepository.php
+++ b/Entity/ProductRepository.php
@@ -8,4 +8,17 @@ use Mautic\CoreBundle\Entity\CommonRepository;
 
 class ProductRepository extends CommonRepository
 {
+    public function search(string $term): array
+    {
+        $queryBuilder = $this->createQueryBuilder('product');
+
+        $queryBuilder
+            ->andWhere('product.name LIKE :name')
+            ->setParameter('name', '%'.$term.'%')
+        ;
+
+        $queryBuilder->orderBy('product.name', 'ASC');
+
+        return $queryBuilder->getQuery()->getResult();
+    }
 }

--- a/EventListener/LeadListSubscriber.php
+++ b/EventListener/LeadListSubscriber.php
@@ -11,6 +11,7 @@ use Mautic\LeadBundle\Provider\TypeOperatorProviderInterface;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Segment\Query\Filter\ForeignFuncFilterQueryBuilder;
 use Mautic\LeadBundle\Segment\Query\Filter\ForeignValueFilterQueryBuilder;
+use MauticPlugin\MauticEcommerceBundle\Segment\Query\Filter\PurchaseProductFilterQueryBuilder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class LeadListSubscriber implements EventSubscriberInterface
@@ -73,6 +74,19 @@ class LeadListSubscriber implements EventSubscriberInterface
                 OperatorOptions::LESS_THAN_OR_EQUAL,
             ]),
         ]);
+
+        $event->addChoice('lead', 'lead_transaction_purchase_product', [
+            'label' => 'Produit acheté',
+            'object' => 'lead',
+            'properties' => [
+                'type' => 'lookup_id',
+                'data-action' => 'plugin:Ecommerce:products'
+            ],
+            'operators' => $this->typeOperatorProvider->getOperatorsIncluding([
+                OperatorOptions::EQUAL_TO,
+                OperatorOptions::NOT_EQUAL_TO,
+            ]),
+        ]);
     }
 
     public function onGenerateSegmentDictionary(SegmentDictionaryGenerationEvent $event): void
@@ -101,6 +115,10 @@ class LeadListSubscriber implements EventSubscriberInterface
             'table_field'         => 'id',
             'func'                => 'sum',
             'field'               => 'price_with_taxes',
+        ]);
+
+        $event->addTranslation('lead_transaction_purchase_product', [
+            'type' => PurchaseProductFilterQueryBuilder::getServiceId(),
         ]);
     }
 }

--- a/Segment/Query/Filter/PurchaseProductFilterQueryBuilder.php
+++ b/Segment/Query/Filter/PurchaseProductFilterQueryBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MauticPlugin\MauticEcommerceBundle\Segment\Query\Filter;
+
+use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\Query\Filter\FilterQueryBuilderInterface;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+
+class PurchaseProductFilterQueryBuilder implements FilterQueryBuilderInterface
+{
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
+    {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
+        $filterOperator  = $filter->getOperator();
+
+        $subQuery = 'SELECT lead_id 
+                     FROM ecommerce_transaction 
+                         INNER JOIN ecommerce_transaction_product
+                             ON ecommerce_transaction.id = ecommerce_transaction_product.transaction_id
+                                    AND  ecommerce_transaction_product.product_id = :productId';
+
+        $queryBuilder
+            ->andWhere($leadsTableAlias. '.id IN (' . $subQuery . ')')
+            ->setParameter('productId', $filter->getParameterValue())
+        ;
+
+        switch ($filterOperator) {
+            case 'eq':
+                $queryBuilder
+                    ->andWhere($leadsTableAlias. '.id IN (' . $subQuery . ')')
+                    ->setParameter('productId', $filter->getParameterValue())
+                ;
+                break;
+            case 'neq':
+                $queryBuilder
+                    ->andWhere($leadsTableAlias. '.id NOT IN (' . $subQuery . ')')
+                    ->setParameter('productId', $filter->getParameterValue())
+                ;
+                break;
+        }
+
+        return $queryBuilder;
+    }
+
+    public static function getServiceId(): string
+    {
+        return 'mautic_ecommerce.lead.query_builder.purchase_product';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": ">=7.4.0 <8.1",
     "mautic/core-lib": "^4.0",
     "symfony/serializer": ">=4.4",
-    "guzzlehttp/oauth-subscriber": "^0.5.0"
+    "guzzlehttp/oauth-subscriber": "^0.6.0"
   },
   "conflict": {
     "guzzlehttp/psr7": ">=2"


### PR DESCRIPTION
-  [x] achat d'un produit X -> attente de https://github.com/mautic/mautic/issues/11316
- [ ] X Achat d'un produit Y -> impossible

Pour l'achat d'un produit on doit d'abord resoudre ce bug : https://github.com/mautic/mautic/issues/11316

La modif a faire si il me dit qu'il y a bien un problème

```js
Mautic.activateSegmentFilterTypeahead = function(displayId, filterId, fieldOptions, mQueryObject) {

    var mQueryBackup = mQuery;

    if (typeof mQueryObject === 'function') {
        mQuery = mQueryObject;
    }

    mQuery('#' + displayId).attr('data-lookup-callback', 'updateLookupListFilter');

    var action = mQuery('#' + displayId).data('action') || 'lead:fieldList';

    Mautic.activateFieldTypeahead(displayId, filterId, [], action)

    mQuery = mQueryBackup;
};
```