### PR TITLE
Indicate the license for Packagist

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,14 +16,8 @@ jobs:
     name: 'Lint'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Do not run on WIP or Draft PRs
-    if: "!github.event.pull_request || (!contains(github.event.pull_request.labels.*.name, 'WIP') && github.event.pull_request.draft == false)"
-    env:
-      working-directory: .
-    defaults:
-      run:
-        # https://github.community/t/use-working-directory-for-entire-job/16747/9
-        working-directory: ${{ env.working-directory }}
+    # Do not run on Draft PRs
+    if: "!github.event.pull_request || github.event.pull_request.draft == false"
 
     steps:
 
@@ -37,6 +31,7 @@ jobs:
           extensions: "json"
           ini-values: "memory_limit=-1"
           php-version: "7.4"
+          tools: "symfony"
 
       - name: 'Determine composer cache directory'
         id: composer-cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .php-cs-fixer.cache
 composer.lock
+.php-version

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+install:
+	symfony composer update
+
 lint: lint.php-cs-fixer lint.phpstan
 
 lint.php-cs-fixer:
@@ -7,10 +10,10 @@ lint.phpstan:
 	symfony php vendor/bin/phpstan analyze --memory-limit=-1
 
 lint.php-cs-fixer@integration:
-	vendor/bin/php-cs-fixer fix  --ansi --dry-run --diff
+	symfony php vendor/bin/php-cs-fixer fix  --ansi --dry-run --diff
 
 install@integration:
 	composer install --ansi --verbose --no-interaction --no-progress --prefer-dist --optimize-autoloader --no-scripts --ignore-platform-reqs
 
 lint.phpstan@integration:
-	vendor/bin/phpstan --no-progress --ansi --no-interaction analyse --configuration ./phpstan.neon.dist
+	symfony php vendor/bin/phpstan --no-progress --ansi --no-interaction analyse --configuration ./phpstan.neon.dist

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "webanyone/mautic-ecommerce-bundle",
   "description": "MauticEcommerceBundle",
+  "license": "GPL-3.0",
   "type": "mautic-plugin",
   "keywords": [
     "mautic",


### PR DESCRIPTION
as well as allowing to setup a specific .php-version for dev purposes and adding a `make install` target